### PR TITLE
jessie: disable pam authentication for cron

### DIFF
--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -7,6 +7,7 @@ RUN install_packages curl ca-certificates cron sudo locales procps libaio1 libss
   DEBIAN_FRONTEND=noninteractive dpkg-reconfigure locales && \
   useradd -ms /bin/bash bitnami && \
   mkdir -p /opt/bitnami && chown bitnami:bitnami /opt/bitnami && \
+  sed -i -e '/pam_loginuid.so/ s/^#*/#/' /etc/pam.d/cron && \
   sed -i -e 's/\s*Defaults\s*secure_path\s*=/# Defaults secure_path=/' /etc/sudoers && \
   echo "bitnami ALL=NOPASSWD: ALL" >> /etc/sudoers
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

Disables the `loginuid` process attribute in `/etc/pam.d/cron`

**Benefits**

<!-- What benefits will be realized by the code change? -->

Fixes the execution of cron jobs

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

No known drawbacks

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- https://github.com/bitnami/bitnami-docker-suitecrm/issues/47