### PR TITLE
Enable a local sha256sum in the cache for testing new packages.

### DIFF
--- a/jessie/rootfs/usr/local/bin/bitnami-pkg
+++ b/jessie/rootfs/usr/local/bin/bitnami-pkg
@@ -15,6 +15,11 @@ print_usage() {
   log "  -c, --checksum             SHA256 verification checksum."
   log "  -h, --help                 Show this help message and exit."
   log ""
+  log "If the package is already available in the /tmp/bitnami/pkg/cache/"
+  log "directory, the download will be skipped. If there is a corresponding"
+  log "file of the same name post-fixed with .sha256 in the directory,"
+  log "that sha will be used instead of the --checksum option."
+  log ""
   log "Examples:"
   log "  - Unpack package"
   log "    \$ bitnami-pkg unpack nginx-1.9.10-0"
@@ -104,6 +109,10 @@ info "Downloading $PACKAGE package"
 if [ -f $CACHE_ROOT/$PACKAGE.tar.gz ]; then
   info "$CACHE_ROOT/$PACKAGE.tar.gz already exists, skipping download."
   cp $CACHE_ROOT/$PACKAGE.tar.gz .
+  if [ -f $CACHE_ROOT/$PACKAGE.tar.gz.sha256 ]; then
+    info "Using the local sha256 from $CACHE_ROOT/$PACKAGE.tar.gz.sha256"
+    PACKAGE_SHA256=$(cat $CACHE_ROOT/$PACKAGE.tar.gz.sha256)
+  fi
 else
   # display cURL progress bar when a tty is attached
   if tty -s; then


### PR DESCRIPTION
**Description of the change**

When testing bitnami packages with a production Dockerfile, developers mount a locally developed package in the /tmp/bitnami/pkg/cache/ directory, which bitnami-pkg already checks and uses relevant packages from there rather than downloading.

But the Dockerfile includes the --checksum option with the current production package sha256sum, and so correctly fails as the cached package differs.

This change enables developers to include .sha256 files with any local packages so the packages can be tested without modifying the Dockerfile.
 
**Benefits**

Enables developers to test new bitnami packages with the current production Dockerfile.

**Possible drawbacks**

None that I can see.

**Additional information**

Example of local testing, first without the .sha256 file:
```
(enable-local-sha256) ~/projects/minideb-extras/jessie$ ls /tmp/bitnami-package-cache/
apache-2.4.25-0-linux-x64-debian-8.tar.gz

(enable-local-sha256) ~/projects/minideb-extras/jessie$ sha256sum /tmp/bitnami-package-cache/apache-2.4.25-0-linux-x64-debian-8.tar.gz | awk '{print $1}'
762c3012b7d1fc5a6a26701a97da524dfcb4407ec2889fd7b0b4322e08848651

(enable-local-sha256) ~/projects/minideb-extras/jessie$ docker run -v "/tmp/bitnami-package-cache/:/tmp/bitnami/pkg/cache/" minideb-extras:latest bitnami-pkg unpack apache-2.4.25-0 --checksum 8b46af7d737772d7d301da8b30a2770b7e549674e33b8a5b07480f53c39f5c3f
INFO  ==> Downloading apache-2.4.25-0-linux-x64-debian-8 package
INFO  ==> /tmp/bitnami/pkg/cache/apache-2.4.25-0-linux-x64-debian-8.tar.gz already exists, skipping download.
INFO  ==> Verifying package integrity
sha256sum: WARNING: 1 computed checksum did NOT match
apache-2.4.25-0-linux-x64-debian-8.tar.gz: FAILED
```

Now create the .sha256 file and retry:
```
(enable-local-sha256) ~/projects/minideb-extras/jessie$ sha256sum /tmp/bitnami-package-cache/apache-2.4.25-0-linux-x64-debian-8.tar.gz | awk '{print $1}' > /tmp/bitnami-package-cache/apache-2.4.25-0-linux-x64-debian-8.tar.gz.sha256

(enable-local-sha256) ~/projects/minideb-extras/jessie$ ls /tmp/bitnami-package-cache/
apache-2.4.25-0-linux-x64-debian-8.tar.gz  apache-2.4.25-0-linux-x64-debian-8.tar.gz.sha256

(enable-local-sha256) ~/projects/minideb-extras/jessie$ cat /tmp/bitnami-package-cache/apache-2.4.25-0-linux-x64-debian-8.tar.gz.sha256 
762c3012b7d1fc5a6a26701a97da524dfcb4407ec2889fd7b0b4322e08848651

(enable-local-sha256) ~/projects/minideb-extras/jessie$ docker run -v "/tmp/bitnami-package-cache/:/tmp/bitnami/pkg/cache/" minideb-extras:latest bitnami-pkg unpack apache-2.4.25-0 --checksum 8b46af7d737772d7d301da8b30a2770b7e549674e33b8a5b07480f53c39f5c3f
INFO  ==> Downloading apache-2.4.25-0-linux-x64-debian-8 package
INFO  ==> /tmp/bitnami/pkg/cache/apache-2.4.25-0-linux-x64-debian-8.tar.gz already exists, skipping download.
INFO  ==> Using the local sha256 from /tmp/bitnami/pkg/cache/apache-2.4.25-0-linux-x64-debian-8.tar.gz.sha256
INFO  ==> Verifying package integrity
apache-2.4.25-0-linux-x64-debian-8.tar.gz: OK
INFO  ==> Unpacking apache-2.4.25-0-linux-x64-debian-8
nami    INFO  Unpacking /tmp/bitnami/pkg/install/apache-2.4.25-0-linux-x64-debian-8
nami    INFO  apache successfully unpacked into /opt/bitnami/apache
```
