### PR TITLE
Modify permissions of install directories

### DIFF
--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -44,7 +44,7 @@ RUN cd /tmp && \
   rm gosu.asc
 
 ENV PATH=/opt/bitnami/nami/bin:$PATH
-ENV BITNAMI_IMAGE_VERSION=jessie-r15
+ENV BITNAMI_IMAGE_VERSION=jessie-r16
 
 COPY rootfs /
 ENTRYPOINT ["/entrypoint.sh"]

--- a/jessie/rootfs/usr/local/bin/bitnami-pkg
+++ b/jessie/rootfs/usr/local/bin/bitnami-pkg
@@ -149,3 +149,10 @@ esac
 nami $1 $PACKAGE $PACKAGE_ARGS
 
 rm -rf $INSTALL_ROOT
+
+if [ "$BITNAMI_PKG_CHMOD" ]; then
+  info "Fixing permissions: chmod $BITNAMI_PKG_CHMOD /.nami /opt/bitnami/$BITNAMI_APP_NAME /bitnami"
+  # Create /bitnami if it doesn't already exist
+  mkdir -p /bitnami
+  chmod $BITNAMI_PKG_CHMOD /.nami /opt/bitnami/$BITNAMI_APP_NAME /bitnami
+fi

--- a/jessie/rootfs/usr/local/bin/bitnami-pkg
+++ b/jessie/rootfs/usr/local/bin/bitnami-pkg
@@ -151,8 +151,8 @@ nami $1 $PACKAGE $PACKAGE_ARGS
 rm -rf $INSTALL_ROOT
 
 if [ "$BITNAMI_PKG_CHMOD" ]; then
-  info "Fixing permissions: chmod $BITNAMI_PKG_CHMOD /.nami /opt/bitnami/$BITNAMI_APP_NAME /bitnami"
+  info "Fixing permissions: chmod $BITNAMI_PKG_CHMOD /.nami /opt/bitnami/$PACKAGE_NAME /bitnami"
   # Create /bitnami if it doesn't already exist
   mkdir -p /bitnami
-  chmod $BITNAMI_PKG_CHMOD /.nami /opt/bitnami/$BITNAMI_APP_NAME /bitnami
+  chmod $BITNAMI_PKG_CHMOD /.nami /opt/bitnami/$PACKAGE_NAME /bitnami
 fi


### PR DESCRIPTION
Adds a feature flag (enabled by setting BITNAMI_PKG_CHMOD) for
correcting permissions in package install directories and nami home.
This enables containers to start correctly as a non-root user in the
root group.