### PR TITLE
removes libssl1.0.0 from `apt install` line

### DIFF
--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -1,7 +1,7 @@
 FROM bitnami/minideb@sha256:bdd77389d7bbe536e0cf442857fabcffb2591fad1553b0e21c3393954bc35d73
 LABEL maintainer "Bitnami <containers@bitnami.com>"
 
-RUN install_packages curl ca-certificates sudo locales procps libaio1 libssl1.0.0 && \
+RUN install_packages curl ca-certificates sudo locales procps libaio1 && \
   update-locale LANG=C.UTF-8 LC_MESSAGES=POSIX && \
   locale-gen en_US.UTF-8 && \
   DEBIAN_FRONTEND=noninteractive dpkg-reconfigure locales && \


### PR DESCRIPTION
libssl will be installed as a dependency of the curl package.
We do not need to explicitly specify the installation of this package.