### PR TITLE
Allow creating extra dirs via BITNAMI_PKG_EXTRA_DIRS env var

### DIFF
--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -43,7 +43,7 @@ RUN cd /tmp && \
   rm gosu.asc
 
 ENV PATH=/opt/bitnami/nami/bin:$PATH
-ENV BITNAMI_IMAGE_VERSION=jessie-r19
+ENV BITNAMI_IMAGE_VERSION=jessie-r20
 
 COPY rootfs /
 ENTRYPOINT ["/entrypoint.sh"]

--- a/jessie/rootfs/usr/local/bin/bitnami-pkg
+++ b/jessie/rootfs/usr/local/bin/bitnami-pkg
@@ -150,6 +150,13 @@ nami $1 $PACKAGE $PACKAGE_ARGS
 
 rm -rf $INSTALL_ROOT
 
+if [ "$BITNAMI_PKG_EXTRA_DIRS" ]; then
+    info "Creating extra directories"
+    for i in  ${BITNAMI_PKG_EXTRA_DIRS}; do
+        mkdir -p $i
+    done
+fi
+
 if [ "$BITNAMI_PKG_CHMOD" ]; then
   info "Fixing permissions: chmod $BITNAMI_PKG_CHMOD /.nami /opt/bitnami/$PACKAGE_NAME /bitnami"
   # Create /bitnami if it doesn't already exist


### PR DESCRIPTION
**Description of the change**

This PR allows specifying a list of directories via an environment variable so the bitnami-pkg script can create them.

**Benefits**

We can create a specific folder so if a user mounts a volume docker won't create the folder with bad permissions. We need all the permissions set at build time for non-root containers.

**Possible drawbacks**

I can't think of any

**Applicable issues**

None