### PR TITLE
BITNAMI_PKG_EXTRA_DIRS permissions and client modules

### DIFF
--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -10,11 +10,11 @@ RUN install_packages curl ca-certificates sudo locales procps libaio1 && \
   sed -i -e 's/\s*Defaults\s*secure_path\s*=/# Defaults secure_path=/' /etc/sudoers && \
   echo "bitnami ALL=NOPASSWD: ALL" >> /etc/sudoers
 
-ENV NAMI_VERSION 0.0.6-0
+ENV NAMI_VERSION 0.0.8-0
 
 RUN cd /tmp && \
   curl -sSLO https://nami-prod.s3.amazonaws.com/tools/nami/releases/nami-$NAMI_VERSION-linux-x64.tar.gz && \
-  echo "08c474bf7b866879cd709f7c3efaebec43cfc2eb39c974fd83c18eb19821129a  nami-$NAMI_VERSION-linux-x64.tar.gz" | sha256sum -c - && \
+  echo "62dcdabc99cb31e1387bdbb8bdb13aa14b47e004bd699a1d681ff305b234c15b  nami-$NAMI_VERSION-linux-x64.tar.gz" | sha256sum -c - && \
   mkdir -p /opt/bitnami/nami && \
   tar xzf nami-$NAMI_VERSION-linux-x64.tar.gz --strip 1 -C /opt/bitnami/nami && \
   rm nami-$NAMI_VERSION-linux-x64.tar.gz

--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -43,7 +43,7 @@ RUN cd /tmp && \
   rm gosu.asc
 
 ENV PATH=/opt/bitnami/nami/bin:$PATH
-ENV BITNAMI_IMAGE_VERSION=jessie-r20
+ENV BITNAMI_IMAGE_VERSION=jessie-r21
 
 COPY rootfs /
 ENTRYPOINT ["/entrypoint.sh"]

--- a/jessie/rootfs/usr/local/bin/bitnami-pkg
+++ b/jessie/rootfs/usr/local/bin/bitnami-pkg
@@ -161,7 +161,7 @@ if [ "$BITNAMI_PKG_CHMOD" ]; then
   DIRS="/.nami /bitnami $BITNAMI_PKG_EXTRA_DIRS"
   # Fix for client modules
   if [[ $PACKAGE_NAME =~ .*-client ]]; then
-    SANITIZED_PACKAGE_NAME=`[[ $PACKAGE_NAME =~ ^(.*)-client ]] && echo ${BASH_REMATCH[1]}`
+    SANITIZED_PACKAGE_NAME=${PACKAGE_NAME%-client}
     DIRS+=" /opt/bitnami/$SANITIZED_PACKAGE_NAME"
   else
     mkdir -p /bitnami/$PACKAGE_NAME

--- a/jessie/rootfs/usr/local/bin/bitnami-pkg
+++ b/jessie/rootfs/usr/local/bin/bitnami-pkg
@@ -161,11 +161,11 @@ if [ "$BITNAMI_PKG_CHMOD" ]; then
   DIRS="/.nami /bitnami $BITNAMI_PKG_EXTRA_DIRS"
   # Fix for client modules
   if [[ $PACKAGE_NAME =~ .*-client ]]; then
-      SANITIZED_PACKAGE_NAME=`[[ $PACKAGE_NAME =~ ^(.*)-client ]] && echo ${BASH_REMATCH[1]}`
-      DIRS+=" /opt/bitnami/$SANITIZED_PACKAGE_NAME"
+    SANITIZED_PACKAGE_NAME=`[[ $PACKAGE_NAME =~ ^(.*)-client ]] && echo ${BASH_REMATCH[1]}`
+    DIRS+=" /opt/bitnami/$SANITIZED_PACKAGE_NAME"
   else
-      mkdir -p /bitnami/$PACKAGE_NAME
-      DIRS+=" /opt/bitnami/$PACKAGE_NAME"
+    mkdir -p /bitnami/$PACKAGE_NAME
+    DIRS+=" /opt/bitnami/$PACKAGE_NAME"
   fi
   info "Fixing permissions: chmod $BITNAMI_PKG_CHMOD $DIRS"
   chmod $BITNAMI_PKG_CHMOD $DIRS

--- a/jessie/rootfs/usr/local/bin/bitnami-pkg
+++ b/jessie/rootfs/usr/local/bin/bitnami-pkg
@@ -151,15 +151,22 @@ nami $1 $PACKAGE $PACKAGE_ARGS
 rm -rf $INSTALL_ROOT
 
 if [ "$BITNAMI_PKG_EXTRA_DIRS" ]; then
-    info "Creating extra directories"
-    for i in  ${BITNAMI_PKG_EXTRA_DIRS}; do
-        mkdir -p $i
-    done
+  info "Creating extra directories"
+  for i in  ${BITNAMI_PKG_EXTRA_DIRS}; do
+    mkdir -p $i
+  done
 fi
 
 if [ "$BITNAMI_PKG_CHMOD" ]; then
-  info "Fixing permissions: chmod $BITNAMI_PKG_CHMOD /.nami /opt/bitnami/$PACKAGE_NAME /bitnami"
-  # Create /bitnami if it doesn't already exist
-  mkdir -p /bitnami/$PACKAGE_NAME
-  chmod $BITNAMI_PKG_CHMOD /.nami /opt/bitnami/$PACKAGE_NAME /bitnami
+  DIRS="/.nami /bitnami $BITNAMI_PKG_EXTRA_DIRS"
+  # Fix for client modules
+  if [[ $PACKAGE_NAME =~ .*-client ]]; then
+      SANITIZED_PACKAGE_NAME=`[[ $PACKAGE_NAME =~ ^(.*)-client ]] && echo ${BASH_REMATCH[1]}`
+      DIRS+=" /opt/bitnami/$SANITIZED_PACKAGE_NAME"
+  else
+      mkdir -p /bitnami/$PACKAGE_NAME
+      DIRS+=" /opt/bitnami/$PACKAGE_NAME"
+  fi
+  info "Fixing permissions: chmod $BITNAMI_PKG_CHMOD $DIRS"
+  chmod $BITNAMI_PKG_CHMOD $DIRS
 fi

--- a/stretch/Dockerfile
+++ b/stretch/Dockerfile
@@ -10,11 +10,11 @@ RUN install_packages curl ca-certificates sudo locales procps libaio1 gnupg dirm
   sed -i -e 's/\s*Defaults\s*secure_path\s*=/# Defaults secure_path=/' /etc/sudoers && \
   echo "bitnami ALL=NOPASSWD: ALL" >> /etc/sudoers
 
-ENV NAMI_VERSION 0.0.6-0
+ENV NAMI_VERSION 0.0.8-0
 
 RUN cd /tmp && \
   curl -sSLO https://nami-prod.s3.amazonaws.com/tools/nami/releases/nami-$NAMI_VERSION-linux-x64.tar.gz && \
-  echo "08c474bf7b866879cd709f7c3efaebec43cfc2eb39c974fd83c18eb19821129a  nami-$NAMI_VERSION-linux-x64.tar.gz" | sha256sum -c - && \
+  echo "62dcdabc99cb31e1387bdbb8bdb13aa14b47e004bd699a1d681ff305b234c15b  nami-$NAMI_VERSION-linux-x64.tar.gz" | sha256sum -c - && \
   mkdir -p /opt/bitnami/nami && \
   tar xzf nami-$NAMI_VERSION-linux-x64.tar.gz --strip 1 -C /opt/bitnami/nami && \
   rm nami-$NAMI_VERSION-linux-x64.tar.gz

--- a/stretch/rootfs/usr/local/bin/bitnami-pkg
+++ b/stretch/rootfs/usr/local/bin/bitnami-pkg
@@ -150,9 +150,23 @@ nami $1 $PACKAGE $PACKAGE_ARGS
 
 rm -rf $INSTALL_ROOT
 
+if [ "$BITNAMI_PKG_EXTRA_DIRS" ]; then
+    info "Creating extra directories"
+    for i in  ${BITNAMI_PKG_EXTRA_DIRS}; do
+        mkdir -p $i
+    done
+fi
+
 if [ "$BITNAMI_PKG_CHMOD" ]; then
-  info "Fixing permissions: chmod $BITNAMI_PKG_CHMOD /.nami /opt/bitnami/$PACKAGE_NAME /bitnami"
-  # Create /bitnami if it doesn't already exist
-  mkdir -p /bitnami/$PACKAGE_NAME
-  chmod $BITNAMI_PKG_CHMOD /.nami /opt/bitnami/$PACKAGE_NAME /bitnami
+    DIRS="/.nami /bitnami $BITNAMI_PKG_EXTRA_DIRS"
+    # Fix for client modules
+    if [[ $PACKAGE_NAME =~ .*-client ]]; then
+        SANITIZED_PACKAGE_NAME=${PACKAGE_NAME%-client}
+        DIRS+=" /opt/bitnami/$SANITIZED_PACKAGE_NAME"
+    else
+        mkdir -p /bitnami/$PACKAGE_NAME
+        DIRS+=" /opt/bitnami/$PACKAGE_NAME"
+    fi
+    info "Fixing permissions: chmod $BITNAMI_PKG_CHMOD $DIRS"
+    chmod $BITNAMI_PKG_CHMOD $DIRS
 fi


### PR DESCRIPTION
**Description of the change**
This PR includes three changes:
* Change permissions for every folder specified in BITNAMI_PKG_EXTRA_DIRS
* Fix issue changing permissions for client modules as $PACKAGE_NAME will  be mysql-client but the folder to change permissions is `/opt/bitnami/mysql`
* Nami has been updated to 0.0.8-0

**Benefits**

* Directories outside /bitnami can get permissions properly set (for example HOME directory for Ghost application)
* It is possible to build the docker image if any client module is needed (for example mysql-client is needed for the ghost image)

**Possible drawbacks**

I don't think so. AFAIK all the client modules behave the same way.

**Applicable issues**

None yet. However, these changes are required in order to run the Ghost image as non-root.

**Additional information**
