### PR TITLE
Update git version in buildpack image

### DIFF
--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -43,7 +43,7 @@ RUN cd /tmp && \
   rm gosu.asc
 
 ENV PATH=/opt/bitnami/nami/bin:$PATH
-ENV BITNAMI_IMAGE_VERSION=jessie-r21
+ENV BITNAMI_IMAGE_VERSION=jessie-r22
 
 COPY rootfs /
 ENTRYPOINT ["/entrypoint.sh"]

--- a/jessie/buildpack/Dockerfile
+++ b/jessie/buildpack/Dockerfile
@@ -1,3 +1,6 @@
 FROM bitnami/minideb-extras:jessie
 
-RUN install_packages build-essential git pkg-config unzip
+ENV PATH="/opt/bitnami/git/bin:$PATH"
+
+RUN install_packages build-essential pkg-config unzip
+RUN bitnami-pkg install git-2.14.1-0 --checksum 6c7935c7f028ab8e8ea38ffab8269b57d87b69b31aae0fc3af8a496e76d0e9cc


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Install specific version of git via nami package instead of install git from debian repositories.

**Benefits**

Old versions of git like the one installed via debian repos  (2.1.4) does not work in non-root containers because the user running the git command is not present in the `/etc/passwd` file. This is the error itself:

```
fatal: unable to look up current user in the passwd file: no such user
```

According to https://github.com/jenkinsci/docker/issues/519 this is fixed since git 2.6.5