### PR TITLE
enable stretch builds

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ jobs:
     docker:
       - image: docker:17.06.0-ce-git
         environment:
-          RELEASE_SERIES_LIST: "jessie"
+          RELEASE_SERIES_LIST: "jessie,stretch"
           LATEST_STABLE: "jessie"
           IMAGE_NAME: minideb-extras
           DOCKER_PROJECT: bitnami

--- a/stretch/Dockerfile
+++ b/stretch/Dockerfile
@@ -22,7 +22,7 @@ RUN cd /tmp && \
 ENV TINI_VERSION v0.13.2
 
 RUN cd /tmp && \
-  gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && \
+  gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && \
   gpg --fingerprint 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 | grep -q "6380 DC42 8747 F6C3 93FE  ACA5 9A84 159D 7001 A4E5" && \
   curl -sSL https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini.asc -o tini.asc && \
   curl -sSL https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini -o /usr/local/bin/tini && \
@@ -34,7 +34,7 @@ ENV GOSU_VERSION=1.10 \
     GOSU_GPG_KEY=B42F6819007F00F88E364FD4036A9C25BF357DD4
 
 RUN cd /tmp && \
-  gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys $GOSU_GPG_KEY && \
+  gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GOSU_GPG_KEY && \
   gpg --fingerprint $GOSU_GPG_KEY | grep -q "B42F 6819 007F 00F8 8E36  4FD4 036A 9C25 BF35 7DD4" && \
   curl -sSL https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64.asc -o gosu.asc && \
   curl -sSL https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64 -o /usr/local/bin/gosu && \


### PR DESCRIPTION
Stretch builds were disabled dues to GPG errors, in this commit we're
using the keyserver ha.pool.sks-keyservers.net to resolve the issue