### PR TITLE
Add ppc64le Dockerfile for minideb-extras

### DIFF
--- a/jessie/Dockerfile.ppc64le
+++ b/jessie/Dockerfile.ppc64le
@@ -1,0 +1,56 @@
+FROM ppc64le/debian:jessie-slim
+LABEL maintainer "Bitnami <containers@bitnami.com>"
+
+RUN apt-get update && apt-get install -y  curl ca-certificates sudo locales procps libaio1 gnupg && \
+  update-locale LANG=C.UTF-8 LC_MESSAGES=POSIX && \
+  locale-gen en_US.UTF-8 && \
+  DEBIAN_FRONTEND=noninteractive dpkg-reconfigure locales && \
+  useradd -ms /bin/bash bitnami && \
+  mkdir -p /opt/bitnami && chown bitnami:bitnami /opt/bitnami && \
+  sed -i -e 's/\s*Defaults\s*secure_path\s*=/# Defaults secure_path=/' /etc/sudoers && \
+  echo "bitnami ALL=NOPASSWD: ALL" >> /etc/sudoers
+
+# The following security actions are recommended by some security scans.
+# https://console.bluemix.net/docs/services/va/va_index.html
+RUN  sed -i 's/^PASS_MAX_DAYS.*/PASS_MAX_DAYS    90/' /etc/login.defs && \
+  sed -i 's/^PASS_MIN_DAYS.*/PASS_MIN_DAYS    1/' /etc/login.defs && \
+  sed -i 's/sha512/sha512 minlen=8/' /etc/pam.d/common-password
+
+ENV NAMI_VERSION=0.0.8-0
+
+RUN cd /tmp && \
+    curl -sSLO https://nami-prod.s3.amazonaws.com/tools/nami/releases/nami-$NAMI_VERSION-linux-ppc64le.tar.gz && \
+    echo "50c85bba4b17794532eb1e134c20d357db6dec3c952cf4ccaea6cc03f2baf455  nami-$NAMI_VERSION-linux-ppc64le.tar.gz" | sha256sum -c - && \
+    mkdir -p /opt/bitnami/nami && \
+    tar xzf nami-$NAMI_VERSION-linux-ppc64le.tar.gz --strip 1 -C /opt/bitnami/nami && \
+    rm nami-$NAMI_VERSION-linux-ppc64le.tar.gz
+
+ENV TINI_VERSION=v0.17.0 \
+    TINI_GPG_KEY=595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7
+
+RUN cd /tmp && \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys $TINI_GPG_KEY && \
+    gpg --fingerprint $TINI_GPG_KEY | grep -q "6380 DC42 8747 F6C3 93FE  ACA5 9A84 159D 7001 A4E5" && \
+    curl -sSL https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-ppc64el.asc -o tini.asc && \
+    curl -sSL https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-ppc64el -o /usr/local/bin/tini && \ 
+    gpg --verify tini.asc /usr/local/bin/tini && \
+    chmod +x /usr/local/bin/tini && \
+    rm tini.asc
+
+ENV GOSU_VERSION=1.10 \
+    GOSU_GPG_KEY=B42F6819007F00F88E364FD4036A9C25BF357DD4
+
+RUN cd /tmp && \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys $GOSU_GPG_KEY && \
+    gpg --fingerprint $GOSU_GPG_KEY | grep -q "B42F 6819 007F 00F8 8E36  4FD4 036A 9C25 BF35 7DD4" && \
+    curl -sSL https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-ppc64el.asc -o gosu.asc && \ 
+    curl -sSL https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-ppc64el -o /usr/local/bin/gosu && \
+    gpg --verify gosu.asc /usr/local/bin/gosu && \
+    chmod +x /usr/local/bin/gosu && \ 
+    rm gosu.asc
+
+ENV PATH=/opt/bitnami/nami/bin:$PATH
+ENV BITNAMI_IMAGE_VERSION=jessie-r24
+
+COPY rootfs /
+ENTRYPOINT ["/entrypoint.sh"]

--- a/jessie/rootfs/usr/local/bin/bitnami-pkg
+++ b/jessie/rootfs/usr/local/bin/bitnami-pkg
@@ -43,6 +43,21 @@ identify_distro() {
   echo "$distro"
 }
 
+identify_arch() {
+  case $(arch) in
+  x86_64)
+    arch=x64
+    ;;
+  ppc64le)
+    arch=ppc64le
+    ;;
+  *)
+   arch="unknown"
+   ;;
+  esac
+  echo $arch
+}
+
 # break up command line for easy parsing and check legal options
 ARGS=$(getopt -o b:c:h -l "bucket:,checksum:,help" -n "bitnami-pkg" -- "$@")
 if [ $? -ne 0 ];
@@ -97,7 +112,7 @@ fi
 INSTALL_ROOT=/tmp/bitnami/pkg/install
 CACHE_ROOT=/tmp/bitnami/pkg/cache
 
-PACKAGE="$2-linux-x64-$(identify_distro)"
+PACKAGE="$2-linux-$(identify_arch)-$(identify_distro)"
 PACKAGE_ARGS=${@:3}
 PACKAGE_NAME=$(echo $PACKAGE | sed 's/-[0-9].*//')
 RELEASE_BUCKET=${RELEASE_BUCKET:-stacksmith}


### PR DESCRIPTION
This PR adds the Dockerfile for the PowerPC64le architecture and updates the `bitnami-pkg` script to look for the nami-module related to the architecture where the tool is being executed.

## Next steps after this PR
- [ ] Push minideb-extras to dockerhub along with the manifest
- [ ] Create the PR to have Redis multiarch