### PR TITLE
Update git in jessie-buildpack and add buildpack for powerpc

### DIFF
--- a/jessie/buildpack/Dockerfile
+++ b/jessie/buildpack/Dockerfile
@@ -3,4 +3,4 @@ FROM bitnami/minideb-extras:jessie
 ENV PATH="/opt/bitnami/git/bin:$PATH"
 
 RUN install_packages build-essential pkg-config unzip
-RUN bitnami-pkg install git-2.14.1-0 --checksum 6c7935c7f028ab8e8ea38ffab8269b57d87b69b31aae0fc3af8a496e76d0e9cc
+RUN bitnami-pkg install git-2.16.2-0 --checksum ea0470e23a705692acca15c6b46ddc4d7c039943732e937c0d627328d5b0f09d

--- a/jessie/buildpack/Dockerfile.ppc64le
+++ b/jessie/buildpack/Dockerfile.ppc64le
@@ -2,5 +2,5 @@ FROM bitnami/minideb-extras
 
 ENV PATH="/opt/bitnami/git/bin:$PATH"
 
-RUN apt-get install build-essential pkg-config unzip -y
+RUN apt-get update && apt-get install build-essential pkg-config unzip -y
 RUN bitnami-pkg install git-2.16.2-0 --checksum 99a55a8c925945b544b99b8ff083beb8c144bac1447b8205dc58299f20818513

--- a/jessie/buildpack/Dockerfile.ppc64le
+++ b/jessie/buildpack/Dockerfile.ppc64le
@@ -1,0 +1,6 @@
+FROM bitnami/minideb-extras
+
+ENV PATH="/opt/bitnami/git/bin:$PATH"
+
+RUN apt-get install build-essential pkg-config unzip -y
+RUN bitnami-pkg install git-2.16.2-0 --checksum 99a55a8c925945b544b99b8ff083beb8c144bac1447b8205dc58299f20818513


### PR DESCRIPTION
As we're going to build all the tags for minideb-extras we will build also the buildpack ones.