### PR TITLE
Update bitnami-pkg: identify_arch and identify_distro

### DIFF
--- a/stretch/Dockerfile
+++ b/stretch/Dockerfile
@@ -61,7 +61,7 @@ RUN cd /tmp && \
   rm gosu.asc
 
 ENV PATH=/opt/bitnami/nami/bin:$PATH
-ENV BITNAMI_IMAGE_VERSION=stretch-r54
+ENV BITNAMI_IMAGE_VERSION=stretch-r55
 
 COPY rootfs /
 ENTRYPOINT ["/entrypoint.sh"]

--- a/stretch/Dockerfile
+++ b/stretch/Dockerfile
@@ -1,5 +1,6 @@
 FROM bitnami/minideb@sha256:e98212fb484381332f4a0992fde0946daa30d0bd9d48be76761f85a1b6e06412
 LABEL maintainer "Bitnami <containers@bitnami.com>"
+ENV IMAGE_OS=debian-9
 
 RUN install_packages curl ca-certificates sudo locales procps libaio1 gnupg dirmngr && \
   update-locale LANG=C.UTF-8 LC_MESSAGES=POSIX && \

--- a/stretch/rootfs/usr/local/bin/bitnami-pkg
+++ b/stretch/rootfs/usr/local/bin/bitnami-pkg
@@ -36,11 +36,40 @@ print_usage() {
 }
 
 identify_distro() {
-  distro="unknown"
-  if [ -f /etc/os-release ]; then
-    distro="$(grep "^ID=" /etc/os-release | cut -d'=' -f2 | cut -d'"' -f2)-$(grep "^VERSION_ID=" /etc/os-release | cut -d'=' -f2 | cut -d'"' -f2)"
+  distro="${IMAGE_OS:-unknown}"
+  if [ "${distro}" == "unknown" -a -f /etc/os-release ]; then
+    distro="$(grep "^ID=" /etc/os-release | cut -d'=' -f2 | cut -d'"' -f2)-$(grep "^VERSION_ID=" /etc/os-release | cut -d'=' -f2 | cut -d'"' -f2 | cut -d'.' -f1)"
   fi
   echo "$distro"
+}
+
+identify_arch() {
+  local arch=$(arch)
+
+  case "${arch}" in
+  ppc64le)
+    ;; # no-op
+  x86_64)
+    case $(identify_distro) in
+    debian-8)
+      arch=x64 # legacy naming
+      ;;
+    debian-*)
+      arch=amd64
+      ;;
+    ol-*)
+      arch=x86_64
+      ;;
+    rhel-*)
+      arch=x86_64
+      ;;
+    esac
+    ;;
+  *)
+    arch="unknown"
+    ;;
+  esac
+  echo $arch
 }
 
 # break up command line for easy parsing and check legal options
@@ -97,7 +126,7 @@ fi
 INSTALL_ROOT=/tmp/bitnami/pkg/install
 CACHE_ROOT=/tmp/bitnami/pkg/cache
 
-PACKAGE="$2-linux-x64-$(identify_distro)"
+PACKAGE="$2-linux-$(identify_arch)-$(identify_distro)"
 PACKAGE_ARGS=${@:3}
 PACKAGE_NAME=$(echo $PACKAGE | sed 's/-[0-9].*//')
 RELEASE_BUCKET=${RELEASE_BUCKET:-stacksmith}
@@ -151,20 +180,20 @@ nami $1 $PACKAGE $PACKAGE_ARGS
 rm -rf $INSTALL_ROOT
 
 if [ "$BITNAMI_PKG_EXTRA_DIRS" ]; then
-    info "Creating extra directories"
-    for i in  ${BITNAMI_PKG_EXTRA_DIRS}; do
-        mkdir -p $i
-    done
+  info "Creating extra directories"
+  for i in  ${BITNAMI_PKG_EXTRA_DIRS}; do
+    mkdir -p $i
+  done
 fi
 
 if [ "$BITNAMI_PKG_CHMOD" ]; then
-    DIRS="/.nami /bitnami $BITNAMI_PKG_EXTRA_DIRS"
-    if ! [[ $PACKAGE_NAME =~ .*-client ]]; then
-      mkdir -p /bitnami/$PACKAGE_NAME
-    fi
-    # We need to be in the $HOME directory in order to nami inspect works
-    cd $HOME
-    DIRS+=" $(nami inspect $PACKAGE_NAME | grep -e 'installdir' | cut -f4 -d\")"
-    info "Fixing permissions: chmod $BITNAMI_PKG_CHMOD $DIRS"
-    chmod $BITNAMI_PKG_CHMOD $DIRS
+  DIRS="/.nami /bitnami $BITNAMI_PKG_EXTRA_DIRS"
+  if ! [[ $PACKAGE_NAME =~ .*-client ]]; then
+    mkdir -p /bitnami/$PACKAGE_NAME
+  fi
+  # We need to be in $HOME in order to nami inspect works
+  cd $HOME
+  DIRS+=" $(nami inspect $PACKAGE_NAME | grep -e 'installdir' | cut -f4 -d\")"
+  info "Fixing permissions: chmod $BITNAMI_PKG_CHMOD $DIRS"
+  chmod $BITNAMI_PKG_CHMOD $DIRS
 fi


### PR DESCRIPTION
```root@88a421b7efea:/# identify_distro() {
>   distro="${IMAGE_OS:-unknown}"
>   if [ "${distro}" == "unknown" -a -f /etc/os-release ]; then
>     distro="$(grep "^ID=" /etc/os-release | cut -d'=' -f2 | cut -d'"' -f2)-$(grep "^VERSION_ID=" /etc/os-release | cut -d'=' -f2 | cut -d'"' -f2 | cut -d'.' -f1)"
>   fi
>   echo "$distro"
> }
root@88a421b7efea:/#
root@88a421b7efea:/# identify_arch() {
>   local arch=$(arch)
>
>   case "${arch}" in
>   ppc64le)
>     ;; # no-op
>   x86_64)
>     case $(identify_distro) in
>     debian-8)
>       arch=x64 # legacy naming
>       ;;
>     debian-*)
>       arch=amd64
>       ;;
>     ol-*)
>       arch=x86_64
>       ;;
>     rhel-*)
>       arch=x86_64
>       ;;
>     esac
>     ;;
>   *)
>     arch="unknown"
>     ;;
>   esac
>   echo $arch
> }
root@88a421b7efea:/# identify_distro
debian-9
root@88a421b7efea:/# identify_arch
amd64
root@88a421b7efea:/#
```