### PR TITLE
Add bsdtar and change bitnami-pkg

### DIFF
--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -1,7 +1,7 @@
 FROM bitnami/minideb@sha256:b678c90feb1c8f2738022efebb656a7cceab5e43f451774c44f71f6947113ec4
 LABEL maintainer "Bitnami <containers@bitnami.com>"
 
-RUN install_packages curl ca-certificates bsdtar sudo locales procps libaio1 && \
+RUN install_packages curl ca-certificates sudo locales procps libaio1 && \
   update-locale LANG=C.UTF-8 LC_MESSAGES=POSIX && \
   locale-gen en_US.UTF-8 && \
   DEBIAN_FRONTEND=noninteractive dpkg-reconfigure locales && \

--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -1,7 +1,7 @@
 FROM bitnami/minideb@sha256:b678c90feb1c8f2738022efebb656a7cceab5e43f451774c44f71f6947113ec4
 LABEL maintainer "Bitnami <containers@bitnami.com>"
 
-RUN install_packages curl ca-certificates sudo locales procps libaio1 && \
+RUN install_packages curl ca-certificates bsdtar sudo locales procps libaio1 && \
   update-locale LANG=C.UTF-8 LC_MESSAGES=POSIX && \
   locale-gen en_US.UTF-8 && \
   DEBIAN_FRONTEND=noninteractive dpkg-reconfigure locales && \
@@ -60,7 +60,7 @@ RUN cd /tmp && \
   rm gosu.asc
 
 ENV PATH=/opt/bitnami/nami/bin:$PATH
-ENV BITNAMI_IMAGE_VERSION=jessie-r98
+ENV BITNAMI_IMAGE_VERSION=jessie-r99
 
 COPY rootfs /
 ENTRYPOINT ["/entrypoint.sh"]

--- a/jessie/rootfs/usr/local/bin/bitnami-pkg
+++ b/jessie/rootfs/usr/local/bin/bitnami-pkg
@@ -156,7 +156,13 @@ if [ "$PACKAGE_SHA256" ]; then
   echo "$PACKAGE_SHA256  $PACKAGE.tar.gz" | sha256sum -c -
 fi
 
-bsdtar -xf $PACKAGE.tar.gz
+PATH_TO_BSDTAR=$(which bsdtar)
+if [ -x "$PATH_TO_BSDTAR" ]; then
+  bsdtar -xf $PACKAGE.tar.gz
+else
+  tar xzf $PACKAGE.tar.gz
+fi
+
 case "$1" in
   install) info "Installing $PACKAGE" ;;
   unpack) info "Unpacking $PACKAGE" ;;

--- a/jessie/rootfs/usr/local/bin/bitnami-pkg
+++ b/jessie/rootfs/usr/local/bin/bitnami-pkg
@@ -156,8 +156,11 @@ if [ "$PACKAGE_SHA256" ]; then
   echo "$PACKAGE_SHA256  $PACKAGE.tar.gz" | sha256sum -c -
 fi
 
-PATH_TO_BSDTAR=$(which bsdtar)
-if [ -x "$PATH_TO_BSDTAR" ]; then
+# If the tarball has too many files, it can trigger a bug
+# in overlayfs when using tar. Install bsdtar in the container image
+# to workaround it. As the overhead is too big (~40 MB), it is not added by 
+# default. Source: https://github.com/coreos/bugs/issues/1095
+if which bsdtar > /dev/null; then
   bsdtar -xf $PACKAGE.tar.gz
 else
   tar xzf $PACKAGE.tar.gz

--- a/jessie/rootfs/usr/local/bin/bitnami-pkg
+++ b/jessie/rootfs/usr/local/bin/bitnami-pkg
@@ -156,7 +156,7 @@ if [ "$PACKAGE_SHA256" ]; then
   echo "$PACKAGE_SHA256  $PACKAGE.tar.gz" | sha256sum -c -
 fi
 
-tar xzf $PACKAGE.tar.gz
+bsdtar -xf $PACKAGE.tar.gz
 case "$1" in
   install) info "Installing $PACKAGE" ;;
   unpack) info "Unpacking $PACKAGE" ;;

--- a/stretch/Dockerfile
+++ b/stretch/Dockerfile
@@ -2,7 +2,7 @@ FROM bitnami/minideb@sha256:8c7b2d3bbe62146429fc00898a4e428a45a0d61d2676c0576492
 LABEL maintainer "Bitnami <containers@bitnami.com>"
 ENV IMAGE_OS=debian-9
 
-RUN install_packages curl ca-certificates sudo libarchive-tools locales procps libaio1 gnupg dirmngr && \
+RUN install_packages curl ca-certificates sudo locales procps libaio1 gnupg dirmngr && \
   update-locale LANG=C.UTF-8 LC_MESSAGES=POSIX && \
   locale-gen en_US.UTF-8 && \
   DEBIAN_FRONTEND=noninteractive dpkg-reconfigure locales && \

--- a/stretch/Dockerfile
+++ b/stretch/Dockerfile
@@ -2,7 +2,7 @@ FROM bitnami/minideb@sha256:8c7b2d3bbe62146429fc00898a4e428a45a0d61d2676c0576492
 LABEL maintainer "Bitnami <containers@bitnami.com>"
 ENV IMAGE_OS=debian-9
 
-RUN install_packages curl ca-certificates sudo locales procps libaio1 gnupg dirmngr && \
+RUN install_packages curl ca-certificates sudo libarchive-tools locales procps libaio1 gnupg dirmngr && \
   update-locale LANG=C.UTF-8 LC_MESSAGES=POSIX && \
   locale-gen en_US.UTF-8 && \
   DEBIAN_FRONTEND=noninteractive dpkg-reconfigure locales && \
@@ -61,7 +61,7 @@ RUN cd /tmp && \
   rm gosu.asc
 
 ENV PATH=/opt/bitnami/nami/bin:$PATH
-ENV BITNAMI_IMAGE_VERSION=stretch-r72
+ENV BITNAMI_IMAGE_VERSION=stretch-r73
 
 COPY rootfs /
 ENTRYPOINT ["/entrypoint.sh"]

--- a/stretch/rootfs/usr/local/bin/bitnami-pkg
+++ b/stretch/rootfs/usr/local/bin/bitnami-pkg
@@ -170,7 +170,7 @@ if [ "$PACKAGE_SHA256" ]; then
   echo "$PACKAGE_SHA256  $PACKAGE.tar.gz" | sha256sum -c -
 fi
 
-tar xzf $PACKAGE.tar.gz
+bsdtar -xf $PACKAGE.tar.gz
 case "$1" in
   install) info "Installing $PACKAGE" ;;
   unpack) info "Unpacking $PACKAGE" ;;

--- a/stretch/rootfs/usr/local/bin/bitnami-pkg
+++ b/stretch/rootfs/usr/local/bin/bitnami-pkg
@@ -170,8 +170,11 @@ if [ "$PACKAGE_SHA256" ]; then
   echo "$PACKAGE_SHA256  $PACKAGE.tar.gz" | sha256sum -c -
 fi
 
-PATH_TO_BSDTAR=$(which bsdtar)
-if [ -x "$PATH_TO_BSDTAR" ]; then
+# If the tarball has too many files, it can trigger a bug
+# in overlayfs when using tar. Install bsdtar in the container image
+# to workaround it. As the overhead is too big (~40 MB), it is not added by 
+# default. Source: https://github.com/coreos/bugs/issues/1095
+if which bsdtar > /dev/null; then
   bsdtar -xf $PACKAGE.tar.gz
 else
   tar xzf $PACKAGE.tar.gz

--- a/stretch/rootfs/usr/local/bin/bitnami-pkg
+++ b/stretch/rootfs/usr/local/bin/bitnami-pkg
@@ -170,7 +170,13 @@ if [ "$PACKAGE_SHA256" ]; then
   echo "$PACKAGE_SHA256  $PACKAGE.tar.gz" | sha256sum -c -
 fi
 
-bsdtar -xf $PACKAGE.tar.gz
+PATH_TO_BSDTAR=$(which bsdtar)
+if [ -x "$PATH_TO_BSDTAR" ]; then
+  bsdtar -xf $PACKAGE.tar.gz
+else
+  tar xzf $PACKAGE.tar.gz
+fi
+
 case "$1" in
   install) info "Installing $PACKAGE" ;;
   unpack) info "Unpacking $PACKAGE" ;;


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Adds bsdtar to the image and changes bitnami-pkg to use bsdtar to extract tarballs

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
Now bigger files should be extractable, avoiding the issue mentioned in https://github.com/coreos/bugs/issues/1095
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

