### PR TITLE
make "stretch" the latest stable release series

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ jobs:
       - image: docker:17.06.0-ce-git
         environment:
           RELEASE_SERIES_LIST: "jessie,stretch"
-          LATEST_STABLE: "jessie"
+          LATEST_STABLE: "stretch"
           IMAGE_NAME: minideb-extras
           IS_BASE_IMAGE: 1
           DOCKER_PROJECT: bitnami


### PR DESCRIPTION
As debian-8 is deprecated, stretch (debian-9) should be the latest stable branch