### PR TITLE
Force gpg to use non interactive shell

### DIFF
--- a/stretch/Dockerfile
+++ b/stretch/Dockerfile
@@ -37,9 +37,9 @@ ENV TINI_GPG_KEY 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7
 
 RUN cd /tmp && \
   for server in $(shuf -e $GPG_KEY_SERVERS_LIST) ; do \
-      gpg --keyserver "$server" --recv-keys $TINI_GPG_KEY && break || : ; \
+      gpg --no-tty --keyserver "$server" --recv-keys $TINI_GPG_KEY && break || : ; \
   done && \
-  gpg --fingerprint $TINI_GPG_KEY | grep -q "6380 DC42 8747 F6C3 93FE  ACA5 9A84 159D 7001 A4E5" && \
+  gpg --no-tty --fingerprint $TINI_GPG_KEY | grep -q "6380 DC42 8747 F6C3 93FE  ACA5 9A84 159D 7001 A4E5" && \
   curl -sSL https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini.asc -o tini.asc && \
   curl -sSL https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini -o /usr/local/bin/tini && \
   gpg --verify tini.asc /usr/local/bin/tini && \
@@ -51,12 +51,12 @@ ENV GOSU_VERSION=1.10 \
 
 RUN cd /tmp && \
   for server in $(shuf -e $GPG_KEY_SERVERS_LIST) ; do \
-      gpg --keyserver "$server" --recv-keys $GOSU_GPG_KEY && break || : ; \
+      gpg --no-tty --keyserver "$server" --recv-keys $GOSU_GPG_KEY && break || : ; \
   done && \
-  gpg --fingerprint $GOSU_GPG_KEY | grep -q "B42F 6819 007F 00F8 8E36  4FD4 036A 9C25 BF35 7DD4" && \
+  gpg --no-tty --fingerprint $GOSU_GPG_KEY | grep -q "B42F 6819 007F 00F8 8E36  4FD4 036A 9C25 BF35 7DD4" && \
   curl -sSL https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64.asc -o gosu.asc && \
   curl -sSL https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64 -o /usr/local/bin/gosu && \
-  gpg --verify gosu.asc /usr/local/bin/gosu && \
+  gpg --no-tty --verify gosu.asc /usr/local/bin/gosu && \
   chmod +x /usr/local/bin/gosu && \
   rm gosu.asc
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
gpg is currently failing because of this error:

```
gpg: cannot open '/dev/tty': No such device or address
```

Adding `--no-tty` fixes the issue

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
