### PR TITLE
Set default values for BASH_DEBUG

### DIFF
--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -60,7 +60,7 @@ RUN cd /tmp && \
   rm gosu.asc
 
 ENV PATH=/opt/bitnami/nami/bin:$PATH
-ENV BITNAMI_IMAGE_VERSION=jessie-r523
+ENV BITNAMI_IMAGE_VERSION=jessie-r524
 
 COPY rootfs /
 ENTRYPOINT ["/entrypoint.sh"]

--- a/jessie/rootfs/opt/bitnami/base/functions
+++ b/jessie/rootfs/opt/bitnami/base/functions
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-[[ $BASH_DEBUG ]] && set -x
+[[ ${BASH_DEBUG:-0} -eq 1 ]] && set -x
 
 BITNAMI_PREFIX=/opt/bitnami
 

--- a/stretch/Dockerfile
+++ b/stretch/Dockerfile
@@ -61,7 +61,7 @@ RUN cd /tmp && \
   rm gosu.asc
 
 ENV PATH=/opt/bitnami/nami/bin:$PATH
-ENV BITNAMI_IMAGE_VERSION=stretch-r493
+ENV BITNAMI_IMAGE_VERSION=stretch-r494
 
 COPY rootfs /
 ENTRYPOINT ["/entrypoint.sh"]

--- a/stretch/rootfs/opt/bitnami/base/functions
+++ b/stretch/rootfs/opt/bitnami/base/functions
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-[[ $BASH_DEBUG ]] && set -x
+[[ ${BASH_DEBUG:-0} -eq 1 ]] && set -x
 
 BITNAMI_PREFIX=/opt/bitnami
 


### PR DESCRIPTION
Added a default value for BASH_DEBUG so functions can be loaded in a `set -o nounset` environment.

